### PR TITLE
Remove html_chapters from index.Rmd

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -3,10 +3,6 @@ title: "A Minimal Bookdown Book"
 author: "Sean Kross"
 date: "`r Sys.Date()`"
 site: bookdown::bookdown_site
-output:
- bookdown::html_chapters:
-   includes:
-     in_header: style.css
 documentclass: book
 bibliography: [book.bib]
 biblio-style: apalike


### PR DESCRIPTION
Again, this format should rarely be used, and it is for very advanced users who want to heavily customize the HTML output. Most users may just want to go with the `gitbook` format.