### PR TITLE
url is supposed to be homepage of the book

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -12,7 +12,7 @@ bibliography: [book.bib]
 biblio-style: apalike
 link-citations: yes
 github-repo: seankross/bookdown-start
-url: 'https\://github.com/seankross/bookdown-start'
+url: 'http\://seankross.com/bookdown-start/'
 description: "Everything you need (and nothing more) to start a bookdown book."
 ---
 


### PR DESCRIPTION
instead of the Github repo. This is important because the cover image will be fetched from `url` + `cover-image`, e.g. https://bookdown.org/yihui/bookdown/images/cover.jpg